### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=vk.com/druulian
 sentence=Adds functionality to useless buttons and different inputs
 paragraph=This shit will give you a pretty debouncer as well as additional functions such as short/mid/long press, clever state recognition.
 category=Device Control
-url=vk.com/druulian
+url=https://vk.com/druulian
 architectures=*


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.